### PR TITLE
ZCS-816 Conditional ivy settings for network build

### DIFF
--- a/ant-global.xml
+++ b/ant-global.xml
@@ -38,7 +38,15 @@
             <fileset dir="${ivy.jar.dir}" includes="*.jar"/>
         </path>
         <taskdef resource="org/apache/ivy/ant/antlib.xml" uri="antlib:org.apache.ivy.ant" classpathref="ivy.lib.path"/>
-        <ivy:settings id="dev.settings" file="../zm-zcs/ivysettings.xml"/>
+        <if>
+          <available file="../zm-network-build" type="dir"/>
+          <then>
+            <ivy:settings id="dev.settings" file="../zm-network-build/ivysettings-network.xml"/>
+          </then>
+          <else>
+            <ivy:settings id="dev.settings" file="../zm-zcs/ivysettings.xml"/>
+          </else>
+        </if>
     </target>
     <!-- common resolve target that should work to resolve dependencies based on ivy.xml for most projects -->
     <target name="resolve" depends="init-ivy" description="resolve dependencies">


### PR DESCRIPTION
If the `zm-network-build` repo is checked-out locally, then
reference the `ivysettings-network.xml` (which includes our
internal maven repository).  If not, reference
`ivysettings.xml`.

This plus another ZCS-816 pull request for `zm-network-build` fixes network builds