### PR TITLE
ZCS-1726 Resolve only xercesImpl from red hat

### DIFF
--- a/ivysettings.xml
+++ b/ivysettings.xml
@@ -26,6 +26,6 @@
     </filesystem>
   </resolvers>
   <modules>
-    <module organisation="xerces" resolver="maven-redhat"/>
+    <module organisation="xerces" name="xercesImpl" resolver="maven-redhat"/>
   </modules>
 </ivysettings>

--- a/ivysettings.xml
+++ b/ivysettings.xml
@@ -26,6 +26,6 @@
     </filesystem>
   </resolvers>
   <modules>
-    <module organisation="xerces" name="xercesImpl" resolver="maven-redhat"/>
+    <module organisation="xerces" name="xercesImpl" revision="2.9.1-patch-01" resolver="maven-redhat"/>
   </modules>
 </ivysettings>


### PR DESCRIPTION
Fix the xerces resolver to use redhat repo only for xerces#xercesImpl;2.9.1-patch-01 dependency