### PR TITLE
ZCS-1661 Add support for publishing zip as artifact from any repo

### DIFF
--- a/ant-global.xml
+++ b/ant-global.xml
@@ -564,6 +564,39 @@
         </if>
     </target>
 
+    <target name="zimbra-zip" depends="set-dev-version" description="Builds zip file from build directory">
+      <condition property="zip.file" value="${ant.project.name}-${dev.version}.zip">
+        <not><isset property="zip.file"/></not>
+      </condition>
+
+      <if>
+        <not>
+          <isset property="zip.build.dir"/>
+        </not>
+        <then>
+          <property name="zip.build.dir" value="${build.dir}"/>
+        </then>
+      </if>
+      <if>
+        <not>
+          <isset property="excludes"/>
+        </not>
+        <then>
+          <property name="excludes" value="${zip.file}"/>
+        </then>
+      </if>
+      <if>
+        <not>
+          <isset property="includes"/>
+        </not>
+        <then>
+          <property name="includes" value=""/>
+        </then>
+      </if>
+
+      <zip destfile="${build.dir}/${zip.file}" update="true" basedir="${zip.build.dir}" includes="${includes}" excludes="${excludes}" />
+    </target>
+
     <target name="clean-cache" description="Delete ivy cache">
         <delete dir="${dev.home}/.ivy2/cache/zimbra/${ant.project.name}"/>
         <delete dir="${dev.home}/.zcs-deps/zimbra/${ant.project.name}"/>

--- a/ant-global.xml
+++ b/ant-global.xml
@@ -619,20 +619,4 @@
     <target name="dist.dependencies">
          <antcall target="depend.${ant.project.name}"/>
     </target>
-
-    <target name="publish-foss-local">
-      <ant dir="${native.dir}" target="publish-local" inheritAll="false"/>
-      <ant dir="${common.dir}" target="publish-local" inheritAll="false"/>
-      <ant dir="${soap.dir}" target="publish-local" inheritAll="false"/>
-      <ant dir="${client.dir}" target="publish-local" inheritAll="false"/>
-      <ant dir="${server.dir}" target="publish-local" inheritAll="false"/>
-    </target>
-
-    <target name="deploy-foss">
-      <ant dir="${native.dir}" target="deploy" inheritAll="false"/>
-      <ant dir="${common.dir}" target="deploy" inheritAll="false"/>
-      <ant dir="${soap.dir}" target="deploy" inheritAll="false"/>
-      <ant dir="${client.dir}" target="deploy" inheritAll="false"/>
-      <ant dir="${server.dir}" target="deploy" inheritAll="false"/>
-    </target>
 </project>

--- a/ivysettings.xml
+++ b/ivysettings.xml
@@ -17,6 +17,16 @@
       </url>
       <ibiblio name="maven-redhat" root="https://maven.repository.redhat.com/ga/" pattern="[organisation]/[module]/[revision]/[module]-[revision].[ext]"/>
     </chain>
+    <chain name="chain-resolver-zip" returnFirst="true">
+      <filesystem name="local">
+        <!-- ivy:install with zip artifacts was failing some times so had to add this line to fix it -->
+        <!-- http://grokbase.com/t/ant/ivy-user/086ct4mr6h/newbie-cant-resolve-zip-files -->
+        <ivy pattern= "${dev.home}/.zcs-deps/[organisation]/[module]/[module]-[revision].xml" />
+        <artifact pattern= "${dev.home}/.zcs-deps/[organisation]/[module]/[module]-[revision].[ext]" />
+        <artifact pattern= "${dev.home}/.zcs-deps/[organisation]-[revision].[ext]" />
+        <artifact pattern= "${dev.home}/.zcs-deps/[organisation].[ext]" />
+      </filesystem>
+    </chain>
     <!-- 'build-tmp' resolver is not part of the chain and is used only for packaging war files -->
     <filesystem name="build-tmp">
       <artifact pattern="${build.tmp.dir}/[module]-[revision].[ext]" />


### PR DESCRIPTION
zm-zcs:ant-global.xml
   - Create a new target zimbra-zip which can be used to publish zips instead of jars from ivy
   - By default jar target will be calling zimbra-jar but caller can override and call zimbra-zip which will publish a zip file
   - removed deploy-foss and publish-foss-local targets as those are related to zm-mailbox which is not using this file currently

zm-zcs:ivysettings.xml
   - when using ivy:install target sometime it was not resolving to proper zip files, so as per suggestion in post http://grokbase.com/t/ant/ivy-user/086ct4mr6h/newbie-cant-resolve-zip-files, I have added ivy pattern line in local resolver