### PR TITLE
ZCS-8017: configuring guava version centrally

### DIFF
--- a/ivysettings.xml
+++ b/ivysettings.xml
@@ -4,6 +4,7 @@
  <property name="httpclient.httpcore.version" value="4.4.11"/>
  <property name="httpclient.async.version" value="4.1.4"/>
  <property name=“dom4j.version” value=“2.1.1"/>
+ <property name="com.google.guava.version" value="28.1-jre"/>
 <settings defaultResolver="chain-resolver" />
   <caches defaultCacheDir="${dev.home}/.ivy2/cache"/>
   <resolvers>


### PR DESCRIPTION
Issue:
Vulnerabilities in older version 23.0 of Guava.

Fix:
Update version to 28.1-jre and make it available centrally