### PR TITLE
ZCS-11112 : Log4j version change to 2.17.1

### DIFF
--- a/ivysettings.xml
+++ b/ivysettings.xml
@@ -3,9 +3,11 @@
  <property name="httpclient.version" value="4.5.8"/>
  <property name="httpclient.httpcore.version" value="4.4.11"/>
  <property name="httpclient.async.version" value="4.1.4"/>
-
  <property name="dom4j.version" value="2.1.1"/>
  <property name="com.google.guava.version" value="28.1-jre"/>
+ <property name="jetty.version" value="9.4.18.v20190429"/>
+ <property name="log4j.core.version" value="2.17.1"/>
+ <property name="log4j.api.version" value="2.17.1"/>
 
 <settings defaultResolver="chain-resolver" />
   <caches defaultCacheDir="${dev.home}/.ivy2/cache"/>


### PR DESCRIPTION
Issue :- Upgrade Log4j version to 2.17.1 added missing jetty.version