### PR TITLE
ZCS-19037:Triggers on-demand metadata rebuild and remove dependency on scheduled Nexus tasks

### DIFF
--- a/ant-global.xml
+++ b/ant-global.xml
@@ -721,7 +721,7 @@
 
         <if>
             <and>
-                <isset property="env.NEXUS_REBUILD_TASK_ID"/>
+                <isset property="env.METADATA_REBUILD_TASK_ID"/>
                 <isset property="env.NEXUS_USER"/>
                 <isset property="env.NEXUS_PASSWORD"/>
             </and>
@@ -745,7 +745,7 @@
                     <arg value="--retry"/><arg value="3"/>
                     <arg value="--retry-delay"/><arg value="5"/>
                     <arg value="--retry-all-errors"/>
-                    <arg value="${nexus.base.url}/service/rest/v1/tasks/${env.NEXUS_REBUILD_TASK_ID}/run"/>
+                    <arg value="${nexus.base.url}/service/rest/v1/tasks/${env.METADATA_REBUILD_TASK_ID}/run"/>
                 </exec>
 
                 <if>

--- a/ant-global.xml
+++ b/ant-global.xml
@@ -702,15 +702,79 @@
     </target>
 
     <!-- publish-remote target -->
-    <target name="publish-remote" depends="init-ivy,set-dev-version"
-            description="Publish artifacts to Nexus Artifactory"
+    <target name="publish-remote"
+            depends="init-ivy,set-dev-version"
+            description="Publish artifacts to Nexus and trigger metadata rebuild"
             if="env.NEXUS_BASE_URL"
             unless="skipPublishRemote">
-      <ivy:resolve settingsRef="dev.settings"/>
-      <property name="remote.publish.revision" value="${dev.version}-develop-snapshot"/>
-      <ivy:publish settingsRef="dev.settings" resolver="nexus-zimbra" pubrevision="${remote.publish.revision}" overwrite="true" publishivy="false" artifactspattern="${build.dir}/${ant.project.name}-${dev.version}.[ext]"/>
-    </target>
 
+        <ivy:resolve settingsRef="dev.settings"/>
+
+        <property name="remote.publish.revision" value="${dev.version}-develop-snapshot"/>
+
+        <ivy:publish settingsRef="dev.settings"
+                     resolver="nexus-zimbra"
+                     pubrevision="${remote.publish.revision}"
+                     overwrite="true"
+                     publishivy="false"
+                     artifactspattern="${build.dir}/${ant.project.name}-${dev.version}.[ext]"/>
+
+        <if>
+            <and>
+                <isset property="env.NEXUS_REBUILD_TASK_ID"/>
+                <isset property="env.NEXUS_USER"/>
+                <isset property="env.NEXUS_PASSWORD"/>
+            </and>
+            <then>
+                <exec executable="sh" failonerror="false">
+                    <arg value="-c"/>
+                    <arg value="printf 'Triggering Nexus metadata rebuild task...\n'"/>
+                </exec>
+
+                <exec executable="curl"
+                      failonerror="false"
+                      resultproperty="nexus.curl.exit"
+                      outputproperty="nexus.http.status">
+
+                    <arg value="--silent"/>
+                    <arg value="--show-error"/>
+                    <arg value="--output"/><arg value="/dev/null"/>
+                    <arg value="--write-out"/><arg value="%{http_code}"/>
+                    <arg value="--user"/><arg value="${nexus.user}:${nexus.password}"/>
+                    <arg value="--request"/><arg value="POST"/>
+                    <arg value="--retry"/><arg value="3"/>
+                    <arg value="--retry-delay"/><arg value="5"/>
+                    <arg value="--retry-all-errors"/>
+                    <arg value="${nexus.base.url}/service/rest/v1/tasks/${env.NEXUS_REBUILD_TASK_ID}/run"/>
+                </exec>
+
+                <if>
+                    <equals arg1="${nexus.http.status}" arg2="204"/>
+                    <then>
+                        <exec executable="sh" failonerror="false">
+                            <arg value="-c"/>
+                            <arg value="printf 'Nexus metadata rebuild triggered successfully.\n'"/>
+                        </exec>
+                    </then>
+
+                    <elseif>
+                        <equals arg1="${nexus.http.status}" arg2="409"/>
+                        <then>
+                            <exec executable="sh" failonerror="false">
+                                <arg value="-c"/>
+                                <arg value="printf 'Nexus metadata rebuild already in progress. Skipping.\n'"/>
+                            </exec>
+                        </then>
+                    </elseif>
+
+                    <else>
+                        <fail message="Nexus metadata rebuild failed. HTTP=${nexus.http.status}, CURL_EXIT=${nexus.curl.exit}"/>
+                    </else>
+                </if>
+            </then>
+        </if>
+    </target>
+    
     <target name="zmlocalconfig">
       <echo>Running localconfig with with argument: ${localconfig-args}</echo>
       <java classname="com.zimbra.cs.localconfig.LocalConfigCLI" fork="true" classpathref="class.path" failonerror="true">


### PR DESCRIPTION
 What below code-addition will do ;- 
* Before triggering metadata rebuild, checks that all three required variables are present — `METADATA_REBUILD_TASK_ID`, `NEXUS_USER`, and `NEXUS_PASSWORD` — if any are missing, silently skips the rebuild step
* Sends a POST request via curl to the Nexus Task API to trigger `maven-metadata.xml `rebuild after artifact publish
* Uses curl's built-in --retry 3 with 5 second delay and --retry-all-errors to handle transient network failures automatically
* If Nexus responds with HTTP 204 — rebuild triggered successfully, logs success message
* If Nexus responds with HTTP 409 — rebuild already in progress from another pipeline, logs and skips gracefully without failing the build
* Any other HTTP response — fails the build immediately with HTTP status and curl exit code for easy debugging